### PR TITLE
Fix: Add multi-arch (arm64) support via multi-stage build (Resolves #20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
-FROM amneziavpn/amneziawg-go:latest
+FROM golang:alpine AS builder
+RUN apk add --no-cache git make gcc musl-dev linux-headers
+RUN git clone https://github.com/amnezia-vpn/amneziawg-go.git && cd amneziawg-go && make && make install
+RUN git clone https://github.com/amnezia-vpn/amneziawg-tools.git && cd amneziawg-tools/src && make && make WITH_WGQUICK=yes install
 
-# Install dependencies for web UI
+FROM alpine:3.19
+
+COPY --from=builder /usr/bin/amneziawg-go /usr/bin/amneziawg-go
+COPY --from=builder /usr/bin/awg /usr/bin/awg
+COPY --from=builder /usr/bin/awg-quick /usr/bin/awg-quick
+
 RUN apk update && apk add \
     python3 \
     py3-pip \
@@ -11,6 +19,9 @@ RUN apk update && apk add \
     certbot \
     certbot-nginx \
     iptables-legacy \
+    bash \
+    iproute2 \
+    openresolv \
     && rm -rf /var/cache/apk/*
 
 RUN pip3 install flask flask_socketio flask-wtf requests python-socketio eventlet --break-system-packages


### PR DESCRIPTION
Fixes #20 

### What does this PR do?
This PR resolves the issue where the AWG server fails to start on `arm64` environments (like Oracle Cloud). The previous base image (`amneziavpn/amneziawg-go:latest`) lacks an `arm64` manifest, which caused the build/run process to fail on ARM architectures. 

To fix this, I replaced the static base image with a **multi-stage build**.

### Key Changes:
1. **Builder Stage:** Uses `golang:alpine` to clone and compile `amneziawg-go` and `amneziawg-tools` directly from the source. 
   * *Note:* I explicitly passed `WITH_WGQUICK=yes` during the make process so the `awg-quick` script is properly generated alongside the `awg` binary.
2. **Final Stage:** Copies the freshly compiled binaries (`amneziawg-go`, `awg`, `awg-quick`) into the clean `alpine:3.19` image.
3. **Crucial Dependencies Added:** I added `bash`, `iproute2`, and `openresolv` to the `apk add` list. Since `awg-quick` is essentially a bash script that relies on the `ip` command to set up the `tun0` interface, these packages are strictly required for the server to start successfully without throwing "command not found" errors.

### Testing
Tested successfully using `docker buildx` for both `linux/amd64` and `linux/arm64` platforms. The image builds smoothly without breaking the existing UI or NGINX configurations.

Let me know if you need any adjustments!