### PR TITLE
Fix client keys generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 1.8.1
+### Fix
+- Fix client keys generation
+
 ## Version 1.8.0
 ### Improvements
 - Switch docker build to source packages instead of ready go-image. ***Potentially*** can be a **BREAKING CHANGE**

--- a/web-ui/app.py
+++ b/web-ui/app.py
@@ -186,9 +186,9 @@ class AmneziaManager:
     def generate_wireguard_keys(self):
         """Generate real WireGuard keys"""
         try:
-            private_key = self.execute_command("wg genkey")
+            private_key = self.execute_command("awg genkey")
             if private_key:
-                public_key = self.execute_command(f"echo '{private_key}' | wg pubkey")
+                public_key = self.execute_command(f"echo '{private_key}' | awg pubkey")
                 return {
                     "private_key": private_key,
                     "public_key": public_key


### PR DESCRIPTION
Fixes #48 

Due to switch awg tools instead of pre-built awg-go image the sames of cli tools changed