### PR TITLE
feat: add WEBUI_BASE_PATH env variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Official docker image repository: https://hub.docker.com/r/alexishw/amneziawg-we
 | `SSL_EMAIL` | `-` | Email used to register Let's encrypt account
 | `SSL_DOMAIN` | `-` | Domain used for SSL cert generation by certbot
 | `IP_LIST` | `-` | A list of IP addresses or IP ranges to allow connections from.
+| `WEBUI_BASE_PATH` | `-` | URL prefix for reverse proxy deployment (e.g., `/amnezia-ui`, `/vpn/admin`). Automatically prepended to all API calls. |
 
 ### Docker Compose Example
 
@@ -254,9 +255,36 @@ docker run -d \
   -e DEFAULT_DNS="8.8.8.8,8.8.4.4" \
   -e SSL_EMAIL="your@email.com" \
   -e SSL_DOMAIN="your.domain.com" \
+  -e WEBUI_BASE_PATH="/amnezia-ui" \
   -v amnezia-data:/etc/amnezia \
   -v ssl:/etc/letsencrypt \
   alexishw/amneziawg-web-ui:master
+```
+
+## Reverse Proxy Deployment
+
+To deploy AmneziaWG Web UI behind a reverse proxy with a custom location prefix, use the `WEBUI_BASE_PATH` environment variable. This automatically prefixes all API calls and WebSocket connections.
+
+### Example: Nginx reverse proxy
+
+```bash
+# Run container with URL prefix
+docker run -d \
+  --name amnezia-web-ui \
+  -e WEBUI_BASE_PATH="/amnezia-ui" \
+  # ... other options ...
+  alexishw/amneziawg-web-ui:master
+```
+
+```nginx
+# Nginx configuration
+location /amnezia-ui/ {
+    proxy_pass http://amnezia-web-ui:80/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+}
 ```
 
 ## SSL certificates issue

--- a/web-ui/app.py
+++ b/web-ui/app.py
@@ -54,6 +54,7 @@ DNS_SERVERS = [dns.strip() for dns in DEFAULT_DNS.split(',') if dns.strip()]
 
 # Fixed values for other settings
 WEB_UI_PORT = 5000
+WEBUI_BASE_PATH = os.getenv('WEBUI_BASE_PATH', '')
 CONFIG_DIR = '/etc/amnezia'
 WIREGUARD_CONFIG_DIR = os.path.join(CONFIG_DIR, 'amneziawg')
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'web_config.json')
@@ -98,6 +99,19 @@ app = Flask(__name__,
     static_folder=STATIC_DIR
 )
 app.secret_key = os.urandom(24)
+app.config['APPLICATION_ROOT'] = WEBUI_BASE_PATH or '/'
+
+# override url_for() to automatically prepend BASE_PATH to all generated URLs
+@app.context_processor
+def inject_url_for():
+    from flask import url_for as flask_url_for
+    def url_for_with_prefix(endpoint, **values):
+        url = flask_url_for(endpoint, **values)
+        if url.startswith('/'):
+            return WEBUI_BASE_PATH + url
+        return url
+    return {'url_for': url_for_with_prefix}
+
 socketio = SocketIO(
     app,
     async_mode='eventlet',
@@ -1288,7 +1302,7 @@ amnezia_manager = AmneziaManager()
 @app.route('/')
 def index():
     print("Serving index.html")
-    return render_template('index.html', version=APP_VERSION)
+    return render_template('index.html', version=APP_VERSION, WEBUI_BASE_PATH=WEBUI_BASE_PATH)
 
 # Explicit static file route to ensure they're served
 @app.route('/static/<path:filename>')

--- a/web-ui/static/js/app.js
+++ b/web-ui/static/js/app.js
@@ -8,6 +8,24 @@ class AmneziaApp {
     }
 
     init() {
+        // Override global fetch to add URL prefix support
+        const originalFetch = window.fetch;
+        window.fetch = (url, options) => {
+            if (typeof url === 'string' && url.startsWith('/')) {
+                url = this.prepareUrl(url);
+            }
+            return originalFetch(url, options);
+        };
+
+        // Override global window.open to add URL prefix support
+        const originalOpen = window.open;
+        window.open = (url, target, features) => {
+            if (typeof url === 'string' && url.startsWith('/')) {
+                url = this.prepareUrl(url);
+            }
+            return originalOpen(url, target, features);
+        };
+
         document.addEventListener('DOMContentLoaded', () => {
             console.log("AmneziaWG Web UI initializing...");
             this.initTheme();
@@ -17,6 +35,12 @@ class AmneziaApp {
             this.loadDefaultISettings();
             this.createLogsSection();
         });
+    }
+
+    // Prepare relative URLs (add WEBUI_BASE_PATH prefix) for requests through reverse proxy 
+    prepareUrl(path) {
+        const prefix = window.WEBUI_BASE_PATH || '';
+        return prefix + path;
     }
 
     // Add uptime loading method
@@ -310,7 +334,7 @@ class AmneziaApp {
         }
 
         this.socket = io(socketUrl, {
-            path: '/socket.io',
+            path: this.prepareUrl('/socket.io'),
             transports: ['polling', 'websocket'],  // Allow both for handshake
             upgrade: true,
             reconnection: true,

--- a/web-ui/templates/index.html
+++ b/web-ui/templates/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AmneziaWG Web UI</title>
+    <script>
+        window.WEBUI_BASE_PATH = '{{ WEBUI_BASE_PATH }}';
+    </script>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='icons/favicon-96x96.png') }}" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='icons/favicon.svg') }}" />
     <link rel="shortcut icon" href="{{ url_for('static', filename='icons/favicon.ico') }}" />


### PR DESCRIPTION
Add optional `WEBUI_BASE_PATH` environment variable to support deploying the UI behind a reverse proxy with URL path prefixes (e.g., `http://localhost:8080/amnezia-ui`). Automatically prefixes all API calls, static assets, and WebSocket connections.